### PR TITLE
Improved performance of searching for the next `Selectable` in scenes with a large number of root objects

### DIFF
--- a/Assets/EasyTab/Source/Drivers/IEasyTabDriver.cs
+++ b/Assets/EasyTab/Source/Drivers/IEasyTabDriver.cs
@@ -1,3 +1,6 @@
+using System.Collections;
+using System.Collections.Generic;
+
 namespace EasyTab
 {
     public interface IEasyTabDriver

--- a/Assets/EasyTab/Source/EasyTabSolver.cs
+++ b/Assets/EasyTab/Source/EasyTabSolver.cs
@@ -26,11 +26,16 @@ namespace EasyTab
         /// </summary>
         private readonly HashSet<GameObject> _visitedGameObjects = new HashSet<GameObject>();
         private readonly EasyTabHierarchySolver _hierarchySolver = new EasyTabHierarchySolver();
+
+        private readonly EasyTabDriver _rootDriver;
         private IEasyTabDriver _driver;
         
         
-        public EasyTabSolver() => _driver = new EasyTabDriver(this);
-        
+        public EasyTabSolver()
+        {
+            _driver = _rootDriver = new EasyTabDriver(this);
+        }
+
         [NotNull]
         public IEasyTabDriver Driver
         {
@@ -47,6 +52,7 @@ namespace EasyTab
             }
             finally // ..but if a real StackOverflowException is thrown, the application will crash
             {
+                _rootDriver.ClearCache();
                 _visitedGameObjects.Clear();
             }
         }
@@ -61,6 +67,7 @@ namespace EasyTab
             }
             finally // ..but if a real StackOverflowException is thrown, the application will crash
             {
+                _rootDriver.ClearCache();
                 _visitedGameObjects.Clear();
             }
         }
@@ -167,9 +174,9 @@ namespace EasyTab
                 return EasyTabNode.None;
             }
 
-            var next2 = GetNextWithoutPolicyImpl(currentNode, reverse);
-            if (next2.Target.IsTransform)
-                return next2;
+            var next = GetNextWithoutPolicyImpl(currentNode, reverse);
+            if (next.Target.IsTransform)
+                return next;
 
             // is jumping continuation in same case...
             if (currentNode.IsSelectable)

--- a/Assets/Tests/Source/PerformanceTests.cs
+++ b/Assets/Tests/Source/PerformanceTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Profiling;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace EasyTab.Tests
+{
+    public class PerformanceTests
+    {
+        [UnityTest]
+        public IEnumerator TimeSpentForTraversingBigTreeMustNotExceedQuota() => Lifetime.DefineAsync(async (lifetime) =>
+        {
+            lifetime.Add(new GameObject(string.Empty, typeof(EventSystem)));
+
+            var easyTabSupport = new EasyTabIntegration();
+            var buttonContainer = new GameObject("buttonContainer");
+            var button = lifetime.Add(new GameObject("1", typeof(Button)));
+            button.transform.SetParent(buttonContainer.transform);
+
+            EventSystem.current.SetSelectedGameObject(button);
+            Assert.AreEqual(button, EventSystem.current.currentSelectedGameObject);
+
+            // buttonContainer.AddComponent<EasyTab>().BorderMode = BorderMode.Roll;
+            
+            for (int i = 0; i < 20; i++)
+            {
+                for (int j = 0; j < 5000; j++)
+                    lifetime.Add(new GameObject(string.Empty));
+                
+                await UniTask.NextFrame();
+            }
+            
+            // cold call
+            easyTabSupport.Navigate();
+            Assert.AreEqual(button, EventSystem.current.currentSelectedGameObject);
+            
+            var timeBeforeNavigate = DateTime.UtcNow;
+            easyTabSupport.Navigate();
+            var timeInNavigation = DateTime.UtcNow - timeBeforeNavigate;
+            
+            Debug.Log($"time for navigation: {timeInNavigation.TotalMilliseconds:F4} ms");
+            Assert.Less(timeInNavigation.TotalMilliseconds, 1000);
+        });
+    }
+}

--- a/Assets/Tests/Source/PerformanceTests.cs.meta
+++ b/Assets/Tests/Source/PerformanceTests.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfb436b64090ab7d19526f961bb4d03eed168f65756e21d87e0d5d1b6b090f2d
+size 83

--- a/Assets/Tests/Source/PrefabCasesTests.cs
+++ b/Assets/Tests/Source/PrefabCasesTests.cs
@@ -41,7 +41,7 @@ namespace EasyTab.Tests
                 easyTabSupport.UpdateLastSelected();
                 EventSystem.current.SetSelectedGameObject(seq.First().gameObject);
             }
-
+            
             foreach (var selectable in seq)
             {
                 var current = EventSystem.current.currentSelectedGameObject;
@@ -49,6 +49,17 @@ namespace EasyTab.Tests
                 easyTabSupport.Navigate(reverse);
                 await UniTask.Delay(TimeSpan.FromSeconds(DelayInSecondsBetweenTabs));
             }
+            
+            LogAssert.NoUnexpectedReceived();
+        });
+
+        [UnityTest]
+        public IEnumerator CyclicTestCase() => Lifetime.DefineAsync(async (lifetime) =>
+        {
+            LogAssert.Expect(LogType.Error,"Cyclic link detected in jumps");
+            LogAssert.Expect(LogType.Error,"Cyclic link detected in jumps");
+            LogAssert.Expect(LogType.Error,"Cyclic link detected in jumps");
+            await TestCase("UseJumpsOrTheirNextTestCase5", false).ToUniTask();
         });
 
 
@@ -116,7 +127,6 @@ namespace EasyTab.Tests
                 yield return new TestCaseData("UseJumpsOrTheirNextTestCase2", false).Returns(null);
                 yield return new TestCaseData("UseJumpsOrTheirNextTestCase3", false).Returns(null);
                 yield return new TestCaseData("UseJumpsOrTheirNextTestCase4", false).Returns(null);
-                yield return new TestCaseData("UseJumpsOrTheirNextTestCase5", false).Returns(null);
                 yield return new TestCaseData("NavigationLockOnMultilineTMPInputFieldCase1", false).Returns(null);
                 yield return new TestCaseData("NavigationForceUnlockOnMultilineTMPInputFieldCase1", true).Returns(null);
                 yield return new TestCaseData("NavigationForceUnlockOnMultilineTMPInputFieldCase1", false).Returns(null);


### PR DESCRIPTION
Improving the performance of the Navigate method depending on the number of root objects:

| N | old time of `Navigate` | new time of `Navigate` |
|---|----------------------|---|
| 20 | 0,1 ms |  0,02 ms |
| 250 | 1,6 ms | 0,2 ms |
| 1000 | 20,8 ms | 1,0 ms |
| 5000 | 455,0 ms | 5,1 ms |
| 20000 | 6973,7 ms | 20,2 ms |
